### PR TITLE
fix: correct broken tool actions and add e2e test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## [Unreleased]
+
+### Bug Fixes
+
+#### `agents_manage`
+- **`list_groups`**: Fixed 404 error — `/agents/:id/groups` does not exist in Freshdesk API v2. Now fetches agent to read `group_ids`, then resolves each via `GET /groups/:id`.
+- **`list_roles`**: Same fix — resolves roles from agent's `role_ids` via `GET /roles/:id`.
+
+#### `companies_manage`
+- **`search`**: Fixed `VALIDATION_ERROR` — Freshdesk search API requires the query wrapped in double quotes. Removed unsupported `per_page` parameter. Updated schema description to document the only valid search field (`domain:`).
+- **`list_contacts`**: Fixed 404 error — `/companies/:id/contacts` does not exist in Freshdesk API v2. Now uses `GET /contacts?company_id=:id`.
+
+#### `contacts_manage`
+- **`search`**: Fixed `VALIDATION_ERROR` — query now wrapped in double quotes. Removed unsupported `per_page` parameter.
+- **`merge`**: Fixed 404 error — was incorrectly using `PUT /contacts/:id/merge`. Correct endpoint is `POST /contacts/merge` with `{ primary_contact_id, secondary_contact_ids }` in the request body.
+
+#### `tickets_manage`
+- **`search`**: Fixed `VALIDATION_ERROR` — query now wrapped in double quotes. Removed unsupported `per_page` parameter. Updated schema description with valid searchable fields and value mappings.
+
+### Added
+
+#### E2E Test Suite (`tests/e2e/freshdesk-tools.e2e.test.ts`)
+- Standalone `tsx`-based test runner (avoids ts-jest + ESM hanging issues with Jest)
+- Covers all 5 tools and 34 actions end-to-end against a real Freshdesk instance
+- Uses timestamp-based unique emails to prevent 409 conflicts on reruns
+- Soft-delete + hard-delete in cleanup to keep emails reusable
+- Spawns MCP server as a subprocess via `StdioClientTransport` from the MCP SDK
+- Run with: `npm run test:e2e`
+
+### Notes
+- **Search syntax**: Freshdesk search API requires the full query wrapped in double quotes (e.g. `"status:2"`). Field values use single quotes (e.g. `"email:'user@example.com'"`).
+- **Hard delete contacts**: Freshdesk requires a contact to be soft-deleted before it can be permanently deleted.
+- **Agent `list_groups` / `list_roles`**: Freshdesk does not expose `/agents/:id/groups` or `/agents/:id/roles` — these are derived by resolving `group_ids` / `role_ids` from the agent record.

--- a/jest.config.e2e.js
+++ b/jest.config.e2e.js
@@ -1,0 +1,24 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/e2e/freshdesk-tools.e2e.test.ts'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
+      useESM: true,
+      tsconfig: {
+        module: 'ESNext',
+        moduleResolution: 'node',
+      },
+    }],
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testTimeout: 60000,
+  verbose: true,
+  maxWorkers: 1,
+  forceExit: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0",
         "axios": "^1.6.0",
+        "dotenv": "^16.5.0",
         "jsonschema": "^1.4.1",
         "lru-cache": "^10.0.1",
         "pino": "^8.16.0",
-        "pino-pretty": "^10.2.3"
+        "pino-pretty": "^10.2.3",
+        "zod": "^3.22.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.8",
@@ -22,7 +24,6 @@
         "@types/node": "^20.9.0",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
-        "dotenv": "^16.5.0",
         "eslint": "^8.53.0",
         "eslint-config-prettier": "^9.0.0",
         "jest": "^29.7.0",
@@ -2889,7 +2890,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:coverage:threshold": "jest --coverage --coverageThreshold='{}' --passWithNoTests",
     "test:unit": "jest tests/unit tests/api tests/auth tests/core tests/tools tests/utils --coverage",
     "test:integration": "jest tests/integration --coverage",
-    "test:e2e": "jest tests/e2e --coverage",
+    "test:e2e": "tsx tests/e2e/freshdesk-tools.e2e.test.ts",
     "test:security": "jest tests/security --coverage",
     "test:mcp:all": "jest --config jest.config.mcp.js tests/mcp --coverage",
     "test:mcp:process": "jest --config jest.config.mcp.js tests/mcp/real-process.test.ts",

--- a/src/tools/agents.ts
+++ b/src/tools/agents.ts
@@ -151,8 +151,10 @@ export class AgentsTool extends BaseTool {
 
   private async listAgentGroups(params: any): Promise<string> {
     const validated = ListAgentGroupsSchema.parse(params);
-    
-    const groups = await this.client.get<any[]>(`/agents/${validated.agent_id}/groups`);
+
+    const agent = await this.client.get<Agent>(`/agents/${validated.agent_id}`);
+    const groupIds: number[] = (agent as any).group_ids ?? [];
+    const groups = await Promise.all(groupIds.map((id: number) => this.client.get<any>(`/groups/${id}`)));
     return this.formatResponse({
       success: true,
       agent_id: validated.agent_id,
@@ -163,8 +165,10 @@ export class AgentsTool extends BaseTool {
 
   private async listAgentRoles(params: any): Promise<string> {
     const validated = ListAgentRolesSchema.parse(params);
-    
-    const roles = await this.client.get<any[]>(`/agents/${validated.agent_id}/roles`);
+
+    const agent = await this.client.get<Agent>(`/agents/${validated.agent_id}`);
+    const roleIds: number[] = (agent as any).role_ids ?? [];
+    const roles = await Promise.all(roleIds.map((id: number) => this.client.get<any>(`/roles/${id}`)));
     return this.formatResponse({
       success: true,
       agent_id: validated.agent_id,

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -42,9 +42,8 @@ const DeleteCompanySchema = z.object({
 });
 
 const SearchCompaniesSchema = z.object({
-  query: z.string().describe('Search query string'),
+  query: z.string().describe('Search query. Valid field: domain (e.g. "domain:\'freshdesk.com\'")'),
   page: z.number().min(1).optional().describe('Page number (default: 1)'),
-  per_page: z.number().min(1).max(100).optional().describe('Items per page (default: 30, max: 100)'),
 });
 
 const ListCompanyContactsSchema = z.object({
@@ -166,11 +165,10 @@ export class CompaniesTool extends BaseTool {
 
   private async searchCompanies(params: any): Promise<string> {
     const validated = SearchCompaniesSchema.parse(params);
-    
+
     const queryParams = {
-      query: validated.query,
+      query: `"${validated.query}"`,
       page: validated.page || 1,
-      per_page: validated.per_page || 30,
     };
 
     const response = await this.client.get<{ results: Company[]; total: number }>('/search/companies', { params: queryParams });
@@ -179,19 +177,19 @@ export class CompaniesTool extends BaseTool {
       companies: response.results,
       total: response.total,
       page: queryParams.page,
-      per_page: queryParams.per_page,
     });
   }
 
   private async listCompanyContacts(params: any): Promise<string> {
     const validated = ListCompanyContactsSchema.parse(params);
-    
+
     const queryParams = {
+      company_id: validated.company_id,
       page: validated.page || 1,
       per_page: validated.per_page || 30,
     };
 
-    const contacts = await this.client.get<any[]>(`/companies/${validated.company_id}/contacts`, { params: queryParams });
+    const contacts = await this.client.get<any[]>('/contacts', { params: queryParams });
     return this.formatResponse({
       success: true,
       company_id: validated.company_id,

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -205,11 +205,10 @@ export class ContactsTool extends BaseTool {
 
   private async searchContacts(params: any): Promise<string> {
     const validated = SearchContactsSchema.parse(params);
-    
+
     const queryParams = {
-      query: validated.query,
+      query: `"${validated.query}"`,
       page: validated.page || 1,
-      per_page: validated.per_page || 30,
     };
 
     const response = await this.client.get<{ results: Contact[]; total: number }>('/search/contacts', { params: queryParams });
@@ -218,14 +217,14 @@ export class ContactsTool extends BaseTool {
       contacts: response.results,
       total: response.total,
       page: queryParams.page,
-      per_page: queryParams.per_page,
     });
   }
 
   private async mergeContacts(params: any): Promise<string> {
     const validated = MergeContactsSchema.parse(params);
     
-    const contact = await this.client.put<Contact>(`/contacts/${validated.primary_contact_id}/merge`, {
+    const contact = await this.client.post<Contact>('/contacts/merge', {
+      primary_contact_id: validated.primary_contact_id,
       secondary_contact_ids: validated.secondary_contact_ids,
     });
 

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -54,9 +54,8 @@ const DeleteTicketSchema = z.object({
 });
 
 const SearchTicketsSchema = z.object({
-  query: z.string().describe('Search query string (e.g., "status:2 priority:1")'),
+  query: z.string().describe('Search query. Valid fields: status (2=Open,3=Pending,4=Resolved,5=Closed), priority (1=Low,2=Medium,3=High,4=Urgent), type, tag, agent_id, group_id, company_id, due_by, created_at, updated_at. Example: "status:2 AND priority:1"'),
   page: z.number().min(1).optional().describe('Page number (default: 1)'),
-  per_page: z.number().min(1).max(100).optional().describe('Items per page (default: 30, max: 100)'),
 });
 
 export class TicketsTool extends BaseTool {
@@ -210,11 +209,10 @@ export class TicketsTool extends BaseTool {
 
   private async searchTickets(params: any): Promise<string> {
     const validated = SearchTicketsSchema.parse(params);
-    
+
     const queryParams = {
-      query: validated.query,
+      query: `"${validated.query}"`,
       page: validated.page || 1,
-      per_page: validated.per_page || 30,
     };
 
     const response = await this.client.get<{ results: Ticket[]; total: number }>('/search/tickets', { params: queryParams });
@@ -223,7 +221,6 @@ export class TicketsTool extends BaseTool {
       tickets: response.results,
       total: response.total,
       page: queryParams.page,
-      per_page: queryParams.per_page,
     });
   }
 }

--- a/tests/e2e/freshdesk-tools.e2e.test.ts
+++ b/tests/e2e/freshdesk-tools.e2e.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Freshdesk MCP E2E Test Suite
+ *
+ * Tests all 28 tool actions against a real Freshdesk account.
+ * Run with: npm run test:e2e
+ * Requires env: FRESHDESK_DOMAIN, FRESHDESK_API_KEY
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ─── mini test runner ────────────────────────────────────────────────────────
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+  duration: number;
+}
+
+const results: TestResult[] = [];
+
+async function test(name: string, fn: () => Promise<void>): Promise<void> {
+  const start = Date.now();
+  try {
+    await fn();
+    results.push({ name, passed: true, duration: Date.now() - start });
+    process.stdout.write(`  ✓ ${name}\n`);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    results.push({ name, passed: false, error, duration: Date.now() - start });
+    process.stdout.write(`  ✗ ${name}\n    ${error}\n`);
+  }
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function suite(name: string): void {
+  process.stdout.write(`\n${name}\n`);
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function callTool(
+  client: Client,
+  tool: string,
+  action: string,
+  params: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const result = await client.callTool({ name: tool, arguments: { action, params } });
+  const text = (result.content as Array<{ text: string }>)[0].text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+// ─── main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const DOMAIN = process.env['FRESHDESK_DOMAIN'];
+  const API_KEY = process.env['FRESHDESK_API_KEY'];
+
+  if (!DOMAIN || !API_KEY) {
+    console.error('ERROR: FRESHDESK_DOMAIN and FRESHDESK_API_KEY env vars are required.');
+    process.exit(1);
+  }
+
+  const serverPath = path.resolve(__dirname, '../../src/index.ts');
+  const tsxPath = path.resolve(__dirname, '../../node_modules/.bin/tsx');
+
+  process.stdout.write('Starting MCP server...\n');
+
+  const transport = new StdioClientTransport({
+    command: tsxPath,
+    args: [serverPath],
+    env: {
+      FRESHDESK_DOMAIN: DOMAIN,
+      FRESHDESK_API_KEY: API_KEY,
+      LOG_LEVEL: 'error',
+      NODE_ENV: 'production',
+      PATH: process.env['PATH'] ?? '',
+      HOME: process.env['HOME'] ?? '',
+    },
+    stderr: 'ignore',
+  });
+
+  const client = new Client({ name: 'e2e-test', version: '1.0.0' }, { capabilities: {} });
+  await client.connect(transport);
+  process.stdout.write('Connected.\n');
+
+  // ── shared state ────────────────────────────────────────────────────────────
+  const ts = Date.now();
+  const testEmail = `e2e.test.${ts}@example.com`;
+  const mergeEmail = `e2e.merge.${ts}@example.com`;
+
+  let agentId = 0;
+  let testCompanyId = 0;
+  let testContactId = 0;
+  let testTicketId = 0;
+  let testReplyId = 0;
+  let testNoteId = 0;
+
+  // ── server ──────────────────────────────────────────────────────────────────
+  suite('Server');
+
+  await test('lists all 5 tools', async () => {
+    const { tools } = await client.listTools();
+    const names = (tools as Array<{ name: string }>).map(t => t.name);
+    const expected = ['tickets_manage', 'contacts_manage', 'agents_manage', 'companies_manage', 'conversations_manage'];
+    for (const name of expected) {
+      assert(names.includes(name), `missing tool: ${name}`);
+    }
+  });
+
+  // ── agents_manage ────────────────────────────────────────────────────────────
+  suite('agents_manage');
+
+  await test('get_current — returns authenticated agent', async () => {
+    const res = await callTool(client, 'agents_manage', 'get_current', {});
+    assert(res.success === true, `success=false: ${JSON.stringify(res)}`);
+    const agent = res.agent as Record<string, unknown>;
+    assert(typeof agent.id === 'number', 'agent.id should be number');
+    agentId = agent.id as number;
+  });
+
+  await test('list — returns array of agents', async () => {
+    const res = await callTool(client, 'agents_manage', 'list', {});
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.agents), 'agents should be array');
+    assert((res.agents as unknown[]).length > 0, 'agents should not be empty');
+  });
+
+  await test('get — retrieves agent by ID', async () => {
+    const res = await callTool(client, 'agents_manage', 'get', { agent_id: agentId });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.agent as Record<string, unknown>).id === agentId, 'agent.id mismatch');
+  });
+
+  await test('update — updates agent fields', async () => {
+    const res = await callTool(client, 'agents_manage', 'update', {
+      agent_id: agentId,
+      occasional: false,
+    });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.agent as Record<string, unknown>).occasional === false, 'occasional should be false');
+  });
+
+  await test('list_groups — returns groups array (may be empty)', async () => {
+    const res = await callTool(client, 'agents_manage', 'list_groups', { agent_id: agentId });
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.groups), 'groups should be array');
+  });
+
+  await test('list_roles — returns roles with details', async () => {
+    const res = await callTool(client, 'agents_manage', 'list_roles', { agent_id: agentId });
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.roles), 'roles should be array');
+    assert((res.roles as unknown[]).length > 0, 'should have at least one role');
+    const role = (res.roles as Array<Record<string, unknown>>)[0];
+    assert(typeof role.id === 'number', 'role.id should be number');
+    assert(typeof role.name === 'string', 'role.name should be string');
+  });
+
+  // ── companies_manage ─────────────────────────────────────────────────────────
+  suite('companies_manage');
+
+  await test('list — returns companies', async () => {
+    const res = await callTool(client, 'companies_manage', 'list', {});
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.companies), 'companies should be array');
+  });
+
+  await test('create — creates test company', async () => {
+    const res = await callTool(client, 'companies_manage', 'create', {
+      name: 'E2E Test Company',
+      description: 'Created by automated e2e test',
+      domains: ['e2etest-mcp.example.com'],
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const company = res.company as Record<string, unknown>;
+    assert(company.name === 'E2E Test Company', 'name mismatch');
+    testCompanyId = company.id as number;
+  });
+
+  await test('get — retrieves created company', async () => {
+    const res = await callTool(client, 'companies_manage', 'get', { company_id: testCompanyId });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.company as Record<string, unknown>).id === testCompanyId, 'id mismatch');
+  });
+
+  await test('update — updates company fields', async () => {
+    const res = await callTool(client, 'companies_manage', 'update', {
+      company_id: testCompanyId,
+      note: 'Updated by e2e test',
+      account_tier: 'Premium',
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const company = res.company as Record<string, unknown>;
+    assert(company.note === 'Updated by e2e test', 'note mismatch');
+    assert(company.account_tier === 'Premium', 'account_tier mismatch');
+  });
+
+  await test('search — finds company by domain (uses pre-existing data)', async () => {
+    // Use pre-existing indexed data — freshly created records may not appear immediately
+    const res = await callTool(client, 'companies_manage', 'search', {
+      query: "domain:'freshdesk.com'",
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const companies = res.companies as Array<Record<string, unknown>>;
+    assert(companies.length > 0, 'should find at least one company');
+  });
+
+  await test('list_contacts — returns contacts for company', async () => {
+    const res = await callTool(client, 'companies_manage', 'list_contacts', { company_id: testCompanyId });
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.contacts), 'contacts should be array');
+  });
+
+  // ── contacts_manage ──────────────────────────────────────────────────────────
+  suite('contacts_manage');
+
+  await test('list — returns contacts', async () => {
+    const res = await callTool(client, 'contacts_manage', 'list', {});
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.contacts), 'contacts should be array');
+  });
+
+  await test('create — creates test contact', async () => {
+    const res = await callTool(client, 'contacts_manage', 'create', {
+      name: 'E2E Test Contact',
+      email: testEmail,
+      phone: '1234567890',
+      job_title: 'QA Engineer',
+      company_id: testCompanyId,
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const contact = res.contact as Record<string, unknown>;
+    assert(contact.name === 'E2E Test Contact', 'name mismatch');
+    assert(contact.email === testEmail, 'email mismatch');
+    testContactId = contact.id as number;
+  });
+
+  await test('get — retrieves created contact', async () => {
+    const res = await callTool(client, 'contacts_manage', 'get', { contact_id: testContactId });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.contact as Record<string, unknown>).id === testContactId, 'id mismatch');
+  });
+
+  await test('update — updates contact fields', async () => {
+    const res = await callTool(client, 'contacts_manage', 'update', {
+      contact_id: testContactId,
+      job_title: 'Senior QA Engineer',
+      address: '1 Test Street',
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const contact = res.contact as Record<string, unknown>;
+    assert(contact.job_title === 'Senior QA Engineer', 'job_title mismatch');
+    assert(contact.address === '1 Test Street', 'address mismatch');
+  });
+
+  await test('search — finds contact by email (uses pre-existing data)', async () => {
+    // Use pre-existing indexed data — freshly created records may not appear immediately
+    const res = await callTool(client, 'contacts_manage', 'search', {
+      query: "email:'emily.dean@globallearning.org'",
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const contacts = res.contacts as Array<Record<string, unknown>>;
+    assert(contacts.length > 0, 'should find at least one contact');
+  });
+
+  await test('merge — merges a second contact into primary', async () => {
+    // Create a second contact to merge
+    const createRes = await callTool(client, 'contacts_manage', 'create', {
+      name: 'E2E Merge Target',
+      email: mergeEmail,
+    });
+    assert(createRes.success === true, JSON.stringify(createRes));
+    const secondId = (createRes.contact as Record<string, unknown>).id as number;
+
+    const res = await callTool(client, 'contacts_manage', 'merge', {
+      primary_contact_id: testContactId,
+      secondary_contact_ids: [secondId],
+    });
+    assert(res.success === true, JSON.stringify(res));
+  });
+
+  // ── tickets_manage ───────────────────────────────────────────────────────────
+  suite('tickets_manage');
+
+  await test('list — returns tickets', async () => {
+    const res = await callTool(client, 'tickets_manage', 'list', {});
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.tickets), 'tickets should be array');
+  });
+
+  await test('create — creates test ticket', async () => {
+    const res = await callTool(client, 'tickets_manage', 'create', {
+      subject: 'E2E Test Ticket',
+      description: '<p>Created by automated e2e test.</p>',
+      email: testEmail,
+      priority: 1,
+      status: 2,
+      tags: ['e2e-test'],
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const ticket = res.ticket as Record<string, unknown>;
+    assert(ticket.subject === 'E2E Test Ticket', 'subject mismatch');
+    testTicketId = ticket.id as number;
+  });
+
+  await test('get — retrieves ticket with description', async () => {
+    const res = await callTool(client, 'tickets_manage', 'get', { ticket_id: testTicketId });
+    assert(res.success === true, JSON.stringify(res));
+    const ticket = res.ticket as Record<string, unknown>;
+    assert(ticket.id === testTicketId, 'id mismatch');
+    assert(typeof ticket.description === 'string', 'description should be string');
+  });
+
+  await test('update — updates ticket priority and status', async () => {
+    const res = await callTool(client, 'tickets_manage', 'update', {
+      ticket_id: testTicketId,
+      priority: 2,
+      status: 3,
+      tags: ['e2e-test', 'updated'],
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const ticket = res.ticket as Record<string, unknown>;
+    assert(ticket.priority === 2, 'priority mismatch');
+    assert(ticket.status === 3, 'status mismatch');
+  });
+
+  await test('search — finds tickets by status (uses pre-existing data)', async () => {
+    // Use pre-existing indexed data — freshly created/updated records may not appear immediately
+    const res = await callTool(client, 'tickets_manage', 'search', { query: 'status:2' });
+    assert(res.success === true, JSON.stringify(res));
+    assert(Array.isArray(res.tickets), 'tickets should be array');
+    assert((res.tickets as unknown[]).length > 0, 'should find open tickets');
+  });
+
+  // ── conversations_manage ─────────────────────────────────────────────────────
+  suite('conversations_manage');
+
+  await test('create_reply — adds public reply', async () => {
+    const res = await callTool(client, 'conversations_manage', 'create_reply', {
+      ticket_id: testTicketId,
+      body: '<p>E2E test reply — please ignore.</p>',
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const conv = res.conversation as Record<string, unknown>;
+    assert(conv.ticket_id === testTicketId, 'ticket_id mismatch');
+    assert(conv.private !== true, 'reply should not be private');
+    testReplyId = conv.id as number;
+  });
+
+  await test('create_note — adds private internal note', async () => {
+    const res = await callTool(client, 'conversations_manage', 'create_note', {
+      ticket_id: testTicketId,
+      body: '<p>E2E internal note — please ignore.</p>',
+      private: true,
+    });
+    assert(res.success === true, JSON.stringify(res));
+    const conv = res.conversation as Record<string, unknown>;
+    assert(conv.private === true, 'note should be private');
+    testNoteId = conv.id as number;
+  });
+
+  await test('list — returns both reply and note', async () => {
+    const res = await callTool(client, 'conversations_manage', 'list', { ticket_id: testTicketId });
+    assert(res.success === true, JSON.stringify(res));
+    const convs = res.conversations as Array<Record<string, unknown>>;
+    assert(convs.length >= 2, `expected >= 2 conversations, got ${convs.length}`);
+    const ids = convs.map(c => c.id);
+    assert(ids.includes(testReplyId), 'reply not found in list');
+    assert(ids.includes(testNoteId), 'note not found in list');
+  });
+
+  await test('get — retrieves reply by ID', async () => {
+    const res = await callTool(client, 'conversations_manage', 'get', { conversation_id: testReplyId });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.conversation as Record<string, unknown>).id === testReplyId, 'id mismatch');
+  });
+
+  await test('update — updates note body', async () => {
+    const res = await callTool(client, 'conversations_manage', 'update', {
+      conversation_id: testNoteId,
+      body: '<p>E2E note UPDATED.</p>',
+    });
+    assert(res.success === true, JSON.stringify(res));
+    assert((res.conversation as Record<string, unknown>).id === testNoteId, 'id mismatch');
+  });
+
+  await test('delete reply', async () => {
+    const res = await callTool(client, 'conversations_manage', 'delete', { conversation_id: testReplyId });
+    assert(res.success === true, JSON.stringify(res));
+    assert(typeof res.message === 'string' && res.message.includes('deleted'), 'unexpected message');
+    testReplyId = 0;
+  });
+
+  await test('delete note', async () => {
+    const res = await callTool(client, 'conversations_manage', 'delete', { conversation_id: testNoteId });
+    assert(res.success === true, JSON.stringify(res));
+    testNoteId = 0;
+  });
+
+  // ── cleanup ──────────────────────────────────────────────────────────────────
+  suite('cleanup');
+
+  await test('delete ticket', async () => {
+    const res = await callTool(client, 'tickets_manage', 'delete', { ticket_id: testTicketId });
+    assert(res.success === true, JSON.stringify(res));
+    testTicketId = 0;
+  });
+
+  await test('delete contact (soft+hard delete to keep email free for reruns)', async () => {
+    // Freshdesk requires soft-delete before hard-delete is allowed
+    await callTool(client, 'contacts_manage', 'delete', { contact_id: testContactId });
+    const res = await callTool(client, 'contacts_manage', 'delete', {
+      contact_id: testContactId,
+      permanent: true,
+    });
+    assert(res.success === true, JSON.stringify(res));
+    testContactId = 0;
+  });
+
+  await test('delete company', async () => {
+    const res = await callTool(client, 'companies_manage', 'delete', { company_id: testCompanyId });
+    assert(res.success === true, JSON.stringify(res));
+    testCompanyId = 0;
+  });
+
+  // ── summary ──────────────────────────────────────────────────────────────────
+  await client.close().catch(() => {});
+
+  const passed = results.filter(r => r.passed).length;
+  const failed = results.filter(r => !r.passed).length;
+  const total = results.length;
+  const totalMs = results.reduce((s, r) => s + r.duration, 0);
+
+  process.stdout.write(`\n${'─'.repeat(50)}\n`);
+  process.stdout.write(`Tests: ${passed} passed, ${failed} failed, ${total} total (${totalMs}ms)\n`);
+
+  if (failed > 0) {
+    process.stdout.write('\nFailed tests:\n');
+    for (const r of results.filter(r => !r.passed)) {
+      process.stdout.write(`  ✗ ${r.name}\n    ${r.error}\n`);
+    }
+    process.exit(1);
+  } else {
+    process.stdout.write('All tests passed.\n');
+    process.exit(0);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **6 bug fixes** across 4 tools that were returning 404 or VALIDATION_ERROR in production
- **E2E test suite** covering all 5 tools and 34 actions (34/34 passing), verified live via MCP connection

## Bug Fixes

| Tool | Action | Issue | Fix |
|------|--------|-------|-----|
| `agents_manage` | `list_groups` | 404 — `/agents/:id/groups` doesn't exist | Resolve via agent's `group_ids` → `GET /groups/:id` |
| `agents_manage` | `list_roles` | 404 — `/agents/:id/roles` doesn't exist | Resolve via agent's `role_ids` → `GET /roles/:id` |
| `companies_manage` | `search` | `VALIDATION_ERROR` — query not double-quoted, unsupported `per_page` | Wrap query in `"..."`, remove `per_page` |
| `companies_manage` | `list_contacts` | 404 — `/companies/:id/contacts` doesn't exist | Use `GET /contacts?company_id=:id` |
| `contacts_manage` | `search` | `VALIDATION_ERROR` — same as above | Wrap query in `"..."`, remove `per_page` |
| `contacts_manage` | `merge` | 404 — wrong endpoint | `POST /contacts/merge` with `{primary_contact_id, secondary_contact_ids}` |
| `tickets_manage` | `search` | `VALIDATION_ERROR` — same as above | Wrap query in `"..."`, remove `per_page`, document valid fields |

## Test Plan

- [x] All 34 e2e actions verified against live Freshdesk instance
- [x] All 34 e2e actions verified live via Claude Code MCP connection
- [x] Hard delete contacts in cleanup (soft-delete first, then permanent) to keep emails reusable across reruns