### PR TITLE
fix: searchTickets query quoting and MCP response size

### DIFF
--- a/src/api/resources/tickets.ts
+++ b/src/api/resources/tickets.ts
@@ -37,7 +37,8 @@ export class TicketsAPI extends BaseResource {
     page?: number;
     per_page?: number;
   }): Promise<{ results: Ticket[]; total: number }> {
-    const params = { query, ...options };
+    // Freshdesk Search API requires query wrapped in double quotes
+    const params = { query: `"${query}"`, ...options };
     const queryString = this.buildQueryString(params);
     return this.client.get<{ results: Ticket[]; total: number }>(`/search/tickets${queryString}`);
   }

--- a/src/tools/tickets-enhanced.ts
+++ b/src/tools/tickets-enhanced.ts
@@ -186,22 +186,27 @@ export class TicketsEnhancedTool extends EnhancedBaseTool {
     const response = await this.client.tickets.search(query, options);
 
     // Strip large fields to keep response within MCP token limits
-    const compactTickets = (response.results || []).map((ticket: any) => ({
-      id: ticket.id,
-      subject: ticket.subject,
-      description_text: ticket.description_text?.substring(0, 200) || '',
-      status: ticket.status,
-      priority: ticket.priority,
-      source: ticket.source,
-      requester_id: ticket.requester_id,
-      responder_id: ticket.responder_id,
-      group_id: ticket.group_id,
-      type: ticket.type,
-      is_escalated: ticket.is_escalated,
-      created_at: ticket.created_at,
-      updated_at: ticket.updated_at,
-      tags: ticket.tags,
-    }));
+    const compactTickets = (response.results || []).map((ticket: any) => {
+      const compact: Record<string, unknown> = {
+        id: ticket.id,
+        subject: ticket.subject,
+      };
+      if (ticket.description_text !== undefined) {
+        compact.description_text = ticket.description_text.substring(0, 200);
+      }
+      if (ticket.status !== undefined) compact.status = ticket.status;
+      if (ticket.priority !== undefined) compact.priority = ticket.priority;
+      if (ticket.source !== undefined) compact.source = ticket.source;
+      if (ticket.requester_id !== undefined) compact.requester_id = ticket.requester_id;
+      if (ticket.responder_id !== undefined) compact.responder_id = ticket.responder_id;
+      if (ticket.group_id !== undefined) compact.group_id = ticket.group_id;
+      if (ticket.type !== undefined) compact.type = ticket.type;
+      if (ticket.is_escalated !== undefined) compact.is_escalated = ticket.is_escalated;
+      if (ticket.created_at !== undefined) compact.created_at = ticket.created_at;
+      if (ticket.updated_at !== undefined) compact.updated_at = ticket.updated_at;
+      if (ticket.tags !== undefined) compact.tags = ticket.tags;
+      return compact;
+    });
 
     return this.formatResponse({
       message: `Found ${compactTickets.length} tickets matching query`,

--- a/src/tools/tickets-enhanced.ts
+++ b/src/tools/tickets-enhanced.ts
@@ -192,19 +192,19 @@ export class TicketsEnhancedTool extends EnhancedBaseTool {
         subject: ticket.subject,
       };
       if (ticket.description_text !== undefined) {
-        compact.description_text = ticket.description_text.substring(0, 200);
+        compact['description_text'] = ticket.description_text.substring(0, 200);
       }
-      if (ticket.status !== undefined) compact.status = ticket.status;
-      if (ticket.priority !== undefined) compact.priority = ticket.priority;
-      if (ticket.source !== undefined) compact.source = ticket.source;
-      if (ticket.requester_id !== undefined) compact.requester_id = ticket.requester_id;
-      if (ticket.responder_id !== undefined) compact.responder_id = ticket.responder_id;
-      if (ticket.group_id !== undefined) compact.group_id = ticket.group_id;
-      if (ticket.type !== undefined) compact.type = ticket.type;
-      if (ticket.is_escalated !== undefined) compact.is_escalated = ticket.is_escalated;
-      if (ticket.created_at !== undefined) compact.created_at = ticket.created_at;
-      if (ticket.updated_at !== undefined) compact.updated_at = ticket.updated_at;
-      if (ticket.tags !== undefined) compact.tags = ticket.tags;
+      if (ticket.status !== undefined) compact['status'] = ticket.status;
+      if (ticket.priority !== undefined) compact['priority'] = ticket.priority;
+      if (ticket.source !== undefined) compact['source'] = ticket.source;
+      if (ticket.requester_id !== undefined) compact['requester_id'] = ticket.requester_id;
+      if (ticket.responder_id !== undefined) compact['responder_id'] = ticket.responder_id;
+      if (ticket.group_id !== undefined) compact['group_id'] = ticket.group_id;
+      if (ticket.type !== undefined) compact['type'] = ticket.type;
+      if (ticket.is_escalated !== undefined) compact['is_escalated'] = ticket.is_escalated;
+      if (ticket.created_at !== undefined) compact['created_at'] = ticket.created_at;
+      if (ticket.updated_at !== undefined) compact['updated_at'] = ticket.updated_at;
+      if (ticket.tags !== undefined) compact['tags'] = ticket.tags;
       return compact;
     });
 

--- a/src/tools/tickets-enhanced.ts
+++ b/src/tools/tickets-enhanced.ts
@@ -184,9 +184,29 @@ export class TicketsEnhancedTool extends EnhancedBaseTool {
     };
 
     const response = await this.client.tickets.search(query, options);
+
+    // Strip large fields to keep response within MCP token limits
+    const compactTickets = (response.results || []).map((ticket: any) => ({
+      id: ticket.id,
+      subject: ticket.subject,
+      description_text: ticket.description_text?.substring(0, 200) || '',
+      status: ticket.status,
+      priority: ticket.priority,
+      source: ticket.source,
+      requester_id: ticket.requester_id,
+      responder_id: ticket.responder_id,
+      group_id: ticket.group_id,
+      type: ticket.type,
+      is_escalated: ticket.is_escalated,
+      created_at: ticket.created_at,
+      updated_at: ticket.updated_at,
+      tags: ticket.tags,
+    }));
+
     return this.formatResponse({
-      message: `Found ${response.results?.length || 0} tickets matching query`,
-      search_results: response,
+      message: `Found ${compactTickets.length} tickets matching query`,
+      tickets: compactTickets,
+      total: response.total,
     });
   }
 }

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -218,22 +218,27 @@ export class TicketsTool extends BaseTool {
     const response = await this.client.get<{ results: Ticket[]; total: number }>('/search/tickets', { params: queryParams });
 
     // Strip large fields to keep response within MCP token limits
-    const compactTickets = response.results.map((ticket: Ticket) => ({
-      id: ticket.id,
-      subject: ticket.subject,
-      description_text: ticket.description_text?.substring(0, 200) || '',
-      status: ticket.status,
-      priority: ticket.priority,
-      source: ticket.source,
-      requester_id: ticket.requester_id,
-      responder_id: ticket.responder_id,
-      group_id: ticket.group_id,
-      type: ticket.type,
-      is_escalated: ticket.is_escalated,
-      created_at: ticket.created_at,
-      updated_at: ticket.updated_at,
-      tags: ticket.tags,
-    }));
+    const compactTickets = response.results.map((ticket: Ticket) => {
+      const compact: Record<string, unknown> = {
+        id: ticket.id,
+        subject: ticket.subject,
+      };
+      if (ticket.description_text !== undefined) {
+        compact.description_text = ticket.description_text.substring(0, 200);
+      }
+      if (ticket.status !== undefined) compact.status = ticket.status;
+      if (ticket.priority !== undefined) compact.priority = ticket.priority;
+      if (ticket.source !== undefined) compact.source = ticket.source;
+      if (ticket.requester_id !== undefined) compact.requester_id = ticket.requester_id;
+      if (ticket.responder_id !== undefined) compact.responder_id = ticket.responder_id;
+      if (ticket.group_id !== undefined) compact.group_id = ticket.group_id;
+      if (ticket.type !== undefined) compact.type = ticket.type;
+      if (ticket.is_escalated !== undefined) compact.is_escalated = ticket.is_escalated;
+      if (ticket.created_at !== undefined) compact.created_at = ticket.created_at;
+      if (ticket.updated_at !== undefined) compact.updated_at = ticket.updated_at;
+      if (ticket.tags !== undefined) compact.tags = ticket.tags;
+      return compact;
+    });
 
     return this.formatResponse({
       success: true,

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -216,9 +216,28 @@ export class TicketsTool extends BaseTool {
     };
 
     const response = await this.client.get<{ results: Ticket[]; total: number }>('/search/tickets', { params: queryParams });
+
+    // Strip large fields to keep response within MCP token limits
+    const compactTickets = response.results.map((ticket: Ticket) => ({
+      id: ticket.id,
+      subject: ticket.subject,
+      description_text: ticket.description_text?.substring(0, 200) || '',
+      status: ticket.status,
+      priority: ticket.priority,
+      source: ticket.source,
+      requester_id: ticket.requester_id,
+      responder_id: ticket.responder_id,
+      group_id: ticket.group_id,
+      type: ticket.type,
+      is_escalated: ticket.is_escalated,
+      created_at: ticket.created_at,
+      updated_at: ticket.updated_at,
+      tags: ticket.tags,
+    }));
+
     return this.formatResponse({
       success: true,
-      tickets: response.results,
+      tickets: compactTickets,
       total: response.total,
       page: queryParams.page,
     });

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -224,19 +224,19 @@ export class TicketsTool extends BaseTool {
         subject: ticket.subject,
       };
       if (ticket.description_text !== undefined) {
-        compact.description_text = ticket.description_text.substring(0, 200);
+        compact['description_text'] = ticket.description_text.substring(0, 200);
       }
-      if (ticket.status !== undefined) compact.status = ticket.status;
-      if (ticket.priority !== undefined) compact.priority = ticket.priority;
-      if (ticket.source !== undefined) compact.source = ticket.source;
-      if (ticket.requester_id !== undefined) compact.requester_id = ticket.requester_id;
-      if (ticket.responder_id !== undefined) compact.responder_id = ticket.responder_id;
-      if (ticket.group_id !== undefined) compact.group_id = ticket.group_id;
-      if (ticket.type !== undefined) compact.type = ticket.type;
-      if (ticket.is_escalated !== undefined) compact.is_escalated = ticket.is_escalated;
-      if (ticket.created_at !== undefined) compact.created_at = ticket.created_at;
-      if (ticket.updated_at !== undefined) compact.updated_at = ticket.updated_at;
-      if (ticket.tags !== undefined) compact.tags = ticket.tags;
+      if (ticket.status !== undefined) compact['status'] = ticket.status;
+      if (ticket.priority !== undefined) compact['priority'] = ticket.priority;
+      if (ticket.source !== undefined) compact['source'] = ticket.source;
+      if (ticket.requester_id !== undefined) compact['requester_id'] = ticket.requester_id;
+      if (ticket.responder_id !== undefined) compact['responder_id'] = ticket.responder_id;
+      if (ticket.group_id !== undefined) compact['group_id'] = ticket.group_id;
+      if (ticket.type !== undefined) compact['type'] = ticket.type;
+      if (ticket.is_escalated !== undefined) compact['is_escalated'] = ticket.is_escalated;
+      if (ticket.created_at !== undefined) compact['created_at'] = ticket.created_at;
+      if (ticket.updated_at !== undefined) compact['updated_at'] = ticket.updated_at;
+      if (ticket.tags !== undefined) compact['tags'] = ticket.tags;
       return compact;
     });
 

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -20,7 +20,7 @@ const mockLogger = {
 
 const mockPino = jest.fn().mockReturnValue(mockLogger);
 
-jest.mock('pino', () => mockPino);
+jest.mock('pino', () => ({ pino: mockPino }));
 
 describe('Logger', () => {
   beforeEach(() => {


### PR DESCRIPTION
Fixes #4

## Changes

### Fix 1 — `src/api/resources/tickets.ts`
The Freshdesk Search API requires the query string wrapped in double quotes. The `search()` method was passing the raw query, causing 400 errors.

```ts
// Before
const params = { query, ...options };

// After
const params = { query: `"${query}"`, ...options };
```

### Fix 2 — `src/tools/tickets.ts`
The `searchTickets` method was returning full ticket objects including HTML description fields, which can easily exceed MCP response token limits. Results are now mapped to a compact representation with `description_text` truncated to 200 characters.

### Fix 3 — `src/tools/tickets-enhanced.ts`
Same compact response mapping applied to the enhanced tool. The 400 error fix flows from Fix 1 (via the API layer), but the response size issue needed to be addressed here separately.

## Testing
- Search with a valid query should now return 200 instead of 400
- Responses with multiple tickets should no longer exceed MCP token limits