### PR TITLE
chore(deps): override minimatch in @typescript-eslint chain to 9.0.7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,13 +5610,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
     "pino-pretty": "^10.2.3",
     "zod": "^3.22.0"
   },
+  "overrides": {
+    "@typescript-eslint/typescript-estree": {
+      "minimatch": "^9.0.7"
+    }
+  },
   "devDependencies": {
     "@types/jest": "^29.5.8",
     "@types/nock": "^10.0.3",


### PR DESCRIPTION
## Summary

Closes the last open high-severity Dependabot alert (minimatch ReDoS, GHSA-7r86-cg39-jmmj) by scoping an npm `overrides` entry to the `@typescript-eslint/typescript-estree` chain.

## Why scoped

Older transitive minimatch versions (3.x, 5.x) pulled by eslint/jest aren't currently flagged, and forcing 9.0.7+ globally would break those consumers. The scoped override only substitutes minimatch *where @typescript-eslint pulls it in*.

## Verification
- `npm audit` — 0 vulnerabilities
- `tsc --noEmit` — clean
- `jest` — 614 pass, 8 pre-existing failures (same as main)