### PR TITLE
feat(conversations): add forward action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Features
+
+#### `conversations_manage`
+- **`forward`**: New action to forward a ticket to other recipients via `POST /tickets/:id/forward`. Accepts `body` and `to_emails` (required), plus optional `cc_emails`, `bcc_emails` and `agent_id`.
+
 ### Bug Fixes
 
 #### `agents_manage`

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ Manage Freshdesk companies - create, update, list, get, delete, search companies
 - `list_contacts`: List contacts in a company
 
 ### 5. conversations_manage
-Manage Freshdesk ticket conversations - create replies and notes, list, get, update, and delete conversations.
+Manage Freshdesk ticket conversations - create replies and notes, forward, list, get, update, and delete conversations.
 
 **Actions:**
 - `create_reply`: Add a reply to a ticket
 - `create_note`: Add a note to a ticket
+- `forward`: Forward a ticket to other email addresses (`to_emails`, optional `cc_emails`/`bcc_emails`/`agent_id`)
 - `list`: List ticket conversations
 - `get`: Get a specific conversation
 - `update`: Update a conversation

--- a/src/api/resources/conversations.ts
+++ b/src/api/resources/conversations.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from './base.js';
-import { Conversation, ConversationReplyData, ConversationNoteData, ConversationUpdateData } from '../../core/types.js';
+import { Conversation, ConversationReplyData, ConversationNoteData, ConversationForwardData, ConversationUpdateData } from '../../core/types.js';
 
 export class ConversationsAPI extends BaseResource {
   async list(ticketId: number, options?: {
@@ -16,6 +16,10 @@ export class ConversationsAPI extends BaseResource {
 
   async createNote(ticketId: number, data: ConversationNoteData): Promise<Conversation> {
     return this.client.post<Conversation>(`/tickets/${ticketId}/notes`, data);
+  }
+
+  async forward(ticketId: number, data: ConversationForwardData): Promise<Conversation> {
+    return this.client.post<Conversation>(`/tickets/${ticketId}/forward`, data);
   }
 
   async update(ticketId: number, conversationId: number, data: ConversationUpdateData): Promise<Conversation> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -294,6 +294,15 @@ export interface ConversationNoteData {
   attachments?: any[];
 }
 
+export interface ConversationForwardData {
+  body: string;
+  to_emails: string[];
+  cc_emails?: string[];
+  bcc_emails?: string[];
+  agent_id?: number;
+  attachments?: any[];
+}
+
 export interface ConversationUpdateData {
   body: string;
 }

--- a/src/tools/conversations-enhanced.ts
+++ b/src/tools/conversations-enhanced.ts
@@ -4,7 +4,7 @@ import { FreshdeskClient } from '../api/client.js';
 import { Permission, AccessLevel } from '../auth/permissions.js';
 
 const ConversationsManageSchema = z.object({
-  action: z.enum(['list', 'create_reply', 'create_note', 'update', 'delete']).describe('Action to perform on conversations'),
+  action: z.enum(['list', 'create_reply', 'create_note', 'forward', 'update', 'delete']).describe('Action to perform on conversations'),
   params: z.object({
     // Common params
     ticket_id: z.number().describe('ID of the ticket').optional(),
@@ -23,6 +23,9 @@ const ConversationsManageSchema = z.object({
     // Create note params
     private: z.boolean().describe('Whether the note is private (default: true)').optional(),
     notify_emails: z.array(z.string().email()).describe('Email addresses to notify about the note').optional(),
+
+    // Forward params
+    agent_id: z.number().describe('ID of the agent forwarding the ticket').optional(),
     
     // Update specific
     conversation_id: z.number().describe('ID of the conversation to update').optional(),
@@ -63,6 +66,8 @@ export class ConversationsEnhancedTool extends EnhancedBaseTool {
           return await this.createReply(params);
         case 'create_note':
           return await this.createNote(params);
+        case 'forward':
+          return await this.forwardTicket(params);
         case 'update':
           return await this.updateConversation(params);
         case 'delete':
@@ -142,6 +147,37 @@ export class ConversationsEnhancedTool extends EnhancedBaseTool {
     const response = await this.client.conversations.createNote(ticket_id, noteData);
     return this.formatResponse({
       message: 'Note created successfully',
+      conversation: response,
+    });
+  }
+
+  private async forwardTicket(params: any): Promise<string> {
+    const { ticket_id, body, to_emails, cc_emails, bcc_emails, agent_id, attachments } = params;
+
+    if (!ticket_id) {
+      throw new Error('ticket_id is required for forward action');
+    }
+
+    if (!body) {
+      throw new Error('body is required for forward action');
+    }
+
+    if (!to_emails || to_emails.length === 0) {
+      throw new Error('to_emails is required for forward action');
+    }
+
+    const forwardData = {
+      body,
+      to_emails,
+      cc_emails,
+      bcc_emails,
+      agent_id,
+      attachments,
+    };
+
+    const response = await this.client.conversations.forward(ticket_id, forwardData);
+    return this.formatResponse({
+      message: 'Ticket forwarded successfully',
       conversation: response,
     });
   }

--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -21,6 +21,15 @@ const CreateNoteSchema = z.object({
   user_id: z.number().optional().describe('ID of the user creating the note (for agents)'),
 });
 
+const ForwardTicketSchema = z.object({
+  ticket_id: z.number().describe('ID of the ticket to forward'),
+  body: z.string().describe('HTML content of the forward message'),
+  to_emails: z.array(z.string().email()).describe('Email addresses to forward the ticket to'),
+  cc_emails: z.array(z.string().email()).optional().describe('CC email addresses'),
+  bcc_emails: z.array(z.string().email()).optional().describe('BCC email addresses'),
+  agent_id: z.number().optional().describe('ID of the agent forwarding the ticket'),
+});
+
 const ListConversationsSchema = z.object({
   ticket_id: z.number().describe('ID of the ticket to get conversations for'),
   page: z.number().min(1).optional().describe('Page number (default: 1)'),
@@ -51,7 +60,7 @@ export class ConversationsTool extends BaseTool {
         properties: {
           action: {
             type: 'string',
-            enum: ['create_reply', 'create_note', 'list', 'get', 'update', 'delete'],
+            enum: ['create_reply', 'create_note', 'forward', 'list', 'get', 'update', 'delete'],
             description: 'Action to perform on conversations',
           },
           params: {
@@ -73,6 +82,8 @@ export class ConversationsTool extends BaseTool {
           return await this.createReply(params);
         case 'create_note':
           return await this.createNote(params);
+        case 'forward':
+          return await this.forwardTicket(params);
         case 'list':
           return await this.listConversations(params);
         case 'get':
@@ -132,6 +143,29 @@ export class ConversationsTool extends BaseTool {
       success: true,
       conversation,
       message: `Note added to ticket #${validated.ticket_id}`,
+    });
+  }
+
+  private async forwardTicket(params: any): Promise<string> {
+    const validated = ForwardTicketSchema.parse(params);
+
+    const forwardData = {
+      body: validated.body,
+      to_emails: validated.to_emails,
+      cc_emails: validated.cc_emails,
+      bcc_emails: validated.bcc_emails,
+      agent_id: validated.agent_id,
+    };
+
+    const conversation = await this.client.post<Conversation>(
+      `/tickets/${validated.ticket_id}/forward`,
+      forwardData
+    );
+
+    return this.formatResponse({
+      success: true,
+      conversation,
+      message: `Ticket #${validated.ticket_id} forwarded to ${validated.to_emails.join(', ')}`,
     });
   }
 

--- a/tests/tools/conversations.test.ts
+++ b/tests/tools/conversations.test.ts
@@ -40,6 +40,7 @@ describe('ConversationsTool', () => {
     it('should route to correct method based on action', async () => {
       const createReplySpy = jest.spyOn(conversationsTool as any, 'createReply').mockResolvedValue('reply result');
       const createNoteSpy = jest.spyOn(conversationsTool as any, 'createNote').mockResolvedValue('note result');
+      const forwardSpy = jest.spyOn(conversationsTool as any, 'forwardTicket').mockResolvedValue('forward result');
       const listSpy = jest.spyOn(conversationsTool as any, 'listConversations').mockResolvedValue('list result');
       const getSpy = jest.spyOn(conversationsTool as any, 'getConversation').mockResolvedValue('get result');
       const updateSpy = jest.spyOn(conversationsTool as any, 'updateConversation').mockResolvedValue('update result');
@@ -47,6 +48,7 @@ describe('ConversationsTool', () => {
 
       expect(createReplySpy).toBeDefined();
       expect(createNoteSpy).toBeDefined();
+      expect(forwardSpy).toBeDefined();
       expect(listSpy).toBeDefined();
       expect(getSpy).toBeDefined();
       expect(updateSpy).toBeDefined();
@@ -54,6 +56,7 @@ describe('ConversationsTool', () => {
 
       await expect(conversationsTool.execute({ action: 'create_reply', params: {} })).resolves.toBe('reply result');
       await expect(conversationsTool.execute({ action: 'create_note', params: {} })).resolves.toBe('note result');
+      await expect(conversationsTool.execute({ action: 'forward', params: {} })).resolves.toBe('forward result');
       await expect(conversationsTool.execute({ action: 'list', params: {} })).resolves.toBe('list result');
       await expect(conversationsTool.execute({ action: 'get', params: {} })).resolves.toBe('get result');
       await expect(conversationsTool.execute({ action: 'update', params: {} })).resolves.toBe('update result');
@@ -148,6 +151,86 @@ describe('ConversationsTool', () => {
       };
 
       await expect(conversationsTool['createReply'](invalidParams)).rejects.toThrow();
+    });
+  });
+
+  describe('forwardTicket', () => {
+    const mockConversation: Conversation = {
+      id: 321,
+      body: 'Forwarded message',
+      body_text: 'Forwarded message',
+      incoming: false,
+      private: true,
+      user_id: 456,
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-01T00:00:00Z',
+    } as Conversation;
+
+    it('should forward a ticket with valid data', async () => {
+      mockClient.post.mockResolvedValue(mockConversation);
+
+      const params = {
+        ticket_id: 789,
+        body: 'Please review this ticket',
+        to_emails: ['itsupport@example.com'],
+      };
+
+      const result = await conversationsTool['forwardTicket'](params);
+      const parsed = JSON.parse(result);
+
+      expect(mockClient.post).toHaveBeenCalledWith('/tickets/789/forward', {
+        body: 'Please review this ticket',
+        to_emails: ['itsupport@example.com'],
+        cc_emails: undefined,
+        bcc_emails: undefined,
+        agent_id: undefined,
+      });
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.conversation).toEqual(mockConversation);
+      expect(parsed.message).toBe('Ticket #789 forwarded to itsupport@example.com');
+    });
+
+    it('should forward with cc, bcc and agent_id', async () => {
+      mockClient.post.mockResolvedValue(mockConversation);
+
+      const params = {
+        ticket_id: 789,
+        body: 'FYI',
+        to_emails: ['a@example.com', 'b@example.com'],
+        cc_emails: ['cc@example.com'],
+        bcc_emails: ['bcc@example.com'],
+        agent_id: 456,
+      };
+
+      await conversationsTool['forwardTicket'](params);
+
+      expect(mockClient.post).toHaveBeenCalledWith('/tickets/789/forward', {
+        body: 'FYI',
+        to_emails: ['a@example.com', 'b@example.com'],
+        cc_emails: ['cc@example.com'],
+        bcc_emails: ['bcc@example.com'],
+        agent_id: 456,
+      });
+    });
+
+    it('should validate required fields', async () => {
+      const invalidParams = {
+        ticket_id: 789,
+        // Missing body and to_emails
+      };
+
+      await expect(conversationsTool['forwardTicket'](invalidParams)).rejects.toThrow();
+    });
+
+    it('should validate email formats', async () => {
+      const invalidParams = {
+        ticket_id: 789,
+        body: 'Test',
+        to_emails: ['invalid-email'],
+      };
+
+      await expect(conversationsTool['forwardTicket'](invalidParams)).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
Descripción:

## Summary
Adds a `forward` action to `conversations_manage` so a ticket can be forwarded to
other recipients, wrapping the Freshdesk `POST /tickets/{id}/forward` endpoint.
This was the one conversation operation missing (only replies and notes existed).
## Changes
- src/api/resources/conversations.ts — new `forward(ticketId, data)` resource method
- src/core/types.ts — new `ConversationForwardData` (body + to_emails required; cc/bcc/agent_id/attachments optional)
- src/tools/conversations.ts & conversations-enhanced.ts — new `forward` action (enum, dispatch, validation of ticket_id/body/to_emails)
- tests/tools/conversations.test.ts — tests for the new action
- README + CHANGELOG updated
## Verification
- `tsc --noEmit` clean
- `eslint` clean on changed files
- `jest tests/tools/conversations.test.ts` → 23/23 passing