### PR TITLE
feat: send_outbound_email action + surface validation errors in handleError

### DIFF
--- a/src/api/resources/tickets.ts
+++ b/src/api/resources/tickets.ts
@@ -1,9 +1,13 @@
 import { BaseResource } from './base.js';
-import { Ticket, TicketCreateData, TicketUpdateData } from '../../core/types.js';
+import { Ticket, TicketCreateData, TicketUpdateData, OutboundEmailData } from '../../core/types.js';
 
 export class TicketsAPI extends BaseResource {
   async create(data: TicketCreateData): Promise<Ticket> {
     return this.client.post<Ticket>('/tickets', data);
+  }
+
+  async sendOutboundEmail(data: OutboundEmailData): Promise<Ticket> {
+    return this.client.post<Ticket>('/tickets/outbound_email', data);
   }
 
   async update(ticketId: number, data: TicketUpdateData): Promise<Ticket> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -203,6 +203,23 @@ export interface TicketUpdateData {
   product_id?: number;
 }
 
+export interface OutboundEmailData {
+  subject: string;
+  description: string;
+  email: string;
+  priority?: Priority;
+  status?: Status;
+  tags?: string[];
+  cc_emails?: string[];
+  bcc_emails?: string[];
+  custom_fields?: Record<string, any>;
+  group_id?: number;
+  responder_id?: number;
+  type?: string;
+  product_id?: number;
+  email_config_id?: number;
+}
+
 export interface ContactCreateData {
   name: string;
   email: string;

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -92,11 +92,34 @@ export abstract class BaseTool {
 
   protected handleError(error: any): string {
     if (error && error.message) {
-      return JSON.stringify({
+      const result: Record<string, unknown> = {
         error: true,
         message: error.message,
         code: error.code || 'UNKNOWN_ERROR',
-      });
+      };
+
+      if (Array.isArray(error.errors) && error.errors.length > 0) {
+        result['errors'] = error.errors.map((e: any) => {
+          if (e && typeof e === 'object') {
+            const clean: Record<string, unknown> = {};
+            if (e.field !== undefined) clean['field'] = e.field;
+            if (e.message !== undefined) clean['message'] = e.message;
+            if (e.code !== undefined) clean['code'] = e.code;
+            return clean;
+          }
+          return e;
+        });
+      }
+
+      if (error.field !== undefined && error.field !== null && error.field !== '') {
+        result['field'] = error.field;
+      }
+
+      if (error.statusCode !== undefined) {
+        result['statusCode'] = error.statusCode;
+      }
+
+      return JSON.stringify(result);
     }
     return JSON.stringify({
       error: true,

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -33,6 +33,23 @@ const UpdateTicketSchema = z.object({
   product_id: z.number().optional().describe('Product ID associated with the ticket'),
 });
 
+const SendOutboundEmailSchema = z.object({
+  subject: z.string().describe('Subject of the outbound email'),
+  description: z.string().describe('HTML body of the outbound email'),
+  email: z.string().email().describe('Email address of the recipient'),
+  priority: z.number().min(1).max(4).optional().describe('Priority: 1=Low, 2=Medium, 3=High, 4=Urgent (default: 1)'),
+  status: z.number().min(2).max(7).optional().describe('Status: 2=Open, 3=Pending, 4=Resolved, 5=Closed, 6=Waiting on Customer, 7=Waiting on Third Party (default: 2)'),
+  tags: z.array(z.string()).optional().describe('Tags for the ticket'),
+  cc_emails: z.array(z.string().email()).optional().describe('Email addresses to CC'),
+  bcc_emails: z.array(z.string().email()).optional().describe('Email addresses to BCC'),
+  custom_fields: z.record(z.any()).optional().describe('Custom fields as key-value pairs'),
+  group_id: z.number().optional().describe('Group ID to assign the ticket'),
+  responder_id: z.number().optional().describe('Agent ID to assign the ticket'),
+  type: z.string().optional().describe('Ticket type'),
+  product_id: z.number().optional().describe('Product ID associated with the ticket'),
+  email_config_id: z.number().optional().describe('Email config ID (support email address to send from)'),
+});
+
 const ListTicketsSchema = z.object({
   page: z.number().min(1).optional().describe('Page number (default: 1)'),
   per_page: z.number().min(1).max(100).optional().describe('Items per page (default: 30, max: 100)'),
@@ -62,13 +79,13 @@ export class TicketsTool extends BaseTool {
   get definition(): Tool {
     return {
       name: 'tickets_manage',
-      description: 'Manage Freshdesk tickets - create, update, list, get, delete, and search tickets',
+      description: 'Manage Freshdesk tickets - create, update, list, get, delete, search, and send outbound emails',
       inputSchema: {
         type: 'object',
         properties: {
           action: {
             type: 'string',
-            enum: ['create', 'update', 'list', 'get', 'delete', 'search'],
+            enum: ['create', 'update', 'list', 'get', 'delete', 'search', 'send_outbound_email'],
             description: 'Action to perform on tickets',
           },
           params: {
@@ -98,6 +115,8 @@ export class TicketsTool extends BaseTool {
           return await this.deleteTicket(params);
         case 'search':
           return await this.searchTickets(params);
+        case 'send_outbound_email':
+          return await this.sendOutboundEmail(params);
         default:
           throw new Error(`Unknown action: ${action}`);
       }
@@ -130,6 +149,34 @@ export class TicketsTool extends BaseTool {
       success: true,
       ticket,
       message: `Ticket #${ticket.id} created successfully`,
+    });
+  }
+
+  private async sendOutboundEmail(params: any): Promise<string> {
+    const validated = SendOutboundEmailSchema.parse(params);
+
+    const emailData = {
+      subject: validated.subject,
+      description: validated.description,
+      email: validated.email,
+      priority: validated.priority as Priority,
+      status: validated.status as Status,
+      tags: validated.tags,
+      cc_emails: validated.cc_emails,
+      bcc_emails: validated.bcc_emails,
+      custom_fields: validated.custom_fields,
+      group_id: validated.group_id,
+      responder_id: validated.responder_id,
+      type: validated.type,
+      product_id: validated.product_id,
+      email_config_id: validated.email_config_id,
+    };
+
+    const ticket = await this.client.post<Ticket>('/tickets/outbound_email', emailData);
+    return this.formatResponse({
+      success: true,
+      ticket,
+      message: `Outbound email sent — Ticket #${ticket.id} created`,
     });
   }
 

--- a/tests/tools/base.test.ts
+++ b/tests/tools/base.test.ts
@@ -418,6 +418,124 @@ describe('BaseTool', () => {
         code: 'STANDARD_ERROR',
       });
     });
+
+    it('should surface errors array when present (e.g. Freshdesk validation errors)', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: [
+          { field: 'custom_fields.cf_status', message: "It should be one of these values: 'active,inactive,pending'", code: 'missing_field' },
+        ],
+      };
+
+      const formatted = testTool['handleError'](error);
+      const parsed = JSON.parse(formatted);
+
+      expect(parsed).toEqual({
+        error: true,
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: [
+          { field: 'custom_fields.cf_status', message: "It should be one of these values: 'active,inactive,pending'", code: 'missing_field' },
+        ],
+      });
+    });
+
+    it('should surface multiple errors when present', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: [
+          { field: 'email', message: 'Invalid email', code: 'invalid' },
+          { field: 'subject', message: 'Subject is required', code: 'missing_field' },
+        ],
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed.errors).toEqual([
+        { field: 'email', message: 'Invalid email', code: 'invalid' },
+        { field: 'subject', message: 'Subject is required', code: 'missing_field' },
+      ]);
+    });
+
+    it('should surface field when present', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        field: 'email',
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed).toEqual({
+        error: true,
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        field: 'email',
+      });
+    });
+
+    it('should surface statusCode when present', () => {
+      const error = {
+        message: 'Not found',
+        code: 'NOT_FOUND',
+        statusCode: 404,
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed).toEqual({
+        error: true,
+        message: 'Not found',
+        code: 'NOT_FOUND',
+        statusCode: 404,
+      });
+    });
+
+    it('should not include errors when array is empty', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: [],
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed).toEqual({
+        error: true,
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+      });
+      expect(parsed.errors).toBeUndefined();
+    });
+
+    it('should not include field when empty string', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        field: '',
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed.field).toBeUndefined();
+    });
+
+    it('should normalize non-object error entries in errors array', () => {
+      const error = {
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: ['plain string error', { field: 'subject', message: 'required', code: 'missing_field' }],
+      };
+
+      const parsed = JSON.parse(testTool['handleError'](error));
+
+      expect(parsed.errors).toEqual([
+        'plain string error',
+        { field: 'subject', message: 'required', code: 'missing_field' },
+      ]);
+    });
   });
 
   describe('execute method', () => {

--- a/tests/tools/tickets.test.ts
+++ b/tests/tools/tickets.test.ts
@@ -40,7 +40,7 @@ describe('TicketsTool', () => {
       const actionProperty = definition.inputSchema.properties?.['action'];
 
       expect((actionProperty as any).enum).toEqual([
-        'create', 'update', 'list', 'get', 'delete', 'search'
+        'create', 'update', 'list', 'get', 'delete', 'search', 'send_outbound_email'
       ]);
     });
   });
@@ -53,6 +53,7 @@ describe('TicketsTool', () => {
       const getSpy = jest.spyOn(ticketsTool as any, 'getTicket').mockResolvedValue('get result');
       const deleteSpy = jest.spyOn(ticketsTool as any, 'deleteTicket').mockResolvedValue('delete result');
       const searchSpy = jest.spyOn(ticketsTool as any, 'searchTickets').mockResolvedValue('search result');
+      const sendOutboundSpy = jest.spyOn(ticketsTool as any, 'sendOutboundEmail').mockResolvedValue('send_outbound_email result');
 
       await expect(ticketsTool.execute({ action: 'create', params: {} })).resolves.toBe('create result');
       await expect(ticketsTool.execute({ action: 'update', params: {} })).resolves.toBe('update result');
@@ -60,6 +61,7 @@ describe('TicketsTool', () => {
       await expect(ticketsTool.execute({ action: 'get', params: {} })).resolves.toBe('get result');
       await expect(ticketsTool.execute({ action: 'delete', params: {} })).resolves.toBe('delete result');
       await expect(ticketsTool.execute({ action: 'search', params: {} })).resolves.toBe('search result');
+      await expect(ticketsTool.execute({ action: 'send_outbound_email', params: {} })).resolves.toBe('send_outbound_email result');
 
       expect(createSpy).toHaveBeenCalledWith({});
       expect(updateSpy).toHaveBeenCalledWith({});
@@ -67,6 +69,7 @@ describe('TicketsTool', () => {
       expect(getSpy).toHaveBeenCalledWith({});
       expect(deleteSpy).toHaveBeenCalledWith({});
       expect(searchSpy).toHaveBeenCalledWith({});
+      expect(sendOutboundSpy).toHaveBeenCalledWith({});
     });
 
     it('should handle unknown action', async () => {


### PR DESCRIPTION
## Summary

Two related changes that together make the `tickets_manage` tool able to send outbound emails and report validation failures usefully.

## Changes

### 1. feat(tickets): add `send_outbound_email` action
Adds support for sending outbound emails via Freshdesk's `POST /tickets/outbound_email` endpoint.

- Add `OutboundEmailData` interface to `core/types`
- Add `sendOutboundEmail()` method to `TicketsAPI` resource
- Add `SendOutboundEmailSchema` and `sendOutboundEmail()` handler to `TicketsTool`
- Register `send_outbound_email` in the action enum
- Update tickets tool tests to cover the new action and routing

### 2. fix(tools): surface `errors[]`, `field`, and `statusCode` in `handleError`
Previously `handleError` only returned `message` and `code`, dropping the detailed `errors[]` array that Freshdesk sends on validation failures. This made failures like a missing `custom_fields.cf_brand` appear as a bare "Validation failed" with no indication of which field was wrong.

`handleError` now also surfaces:
- `errors[]` (cleaned to `field`/`message`/`code` per entry, non-objects preserved)
- `field` (top-level, omitted when empty string)
- `statusCode`

Backward compatible: existing error shapes still serialize identically (Jest's `toEqual` ignores `undefined`).

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm run build` — passes
- `npm run test:unit` — **448/448 tests pass** (11 suites, 0 failures)
  - 7 new tests in `tests/tools/base.test.ts` covering the new error-surfacing behavior
  - Updated `tests/tools/tickets.test.ts` to cover the new action enum value and routing

Full `npm test` hangs on e2e/integration tests that require a live Freshdesk server — not affected by these changes.